### PR TITLE
[addon.xml] Make IARL a game add-on

### DIFF
--- a/plugin.program.iarl/addon.xml
+++ b/plugin.program.iarl/addon.xml
@@ -6,7 +6,7 @@
     <import addon="script.module.requests" version="2.6.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
-    <provides>video</provides>
+    <provides>game</provides>
   </extension>
   <extension point="xbmc.addon.metadata">
     <platform>all</platform>


### PR DESCRIPTION
This will cause IARL to show up under game add-ons instead of video add-ons

`<provides>game</provides>` is a new type of source in the RetroPlayer branch
