### PR TITLE
Remove libretro core selection dialog when launching games

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -295,32 +295,28 @@ def download_and_launch_rom(romwindow,rom_fname,rom_sfname, rom_save_fname, rom_
             print 'IARL Error:  No external launch command is defined'
 
     else: #Otherwise use retroplayer
-        success, selectedcore = selectlibretrocore()
+        download_success, new_rom_fname, new_rom_sfname = download_rom_only(rom_fname,rom_sfname, rom_save_fname, rom_save_sfname, rom_dl_path, rom_postdlaction)
+        current_path = getTempDir()
+        current_save_fname = current_path+'/'+rom_save_fname
+        current_save_sfname = current_path+'/'+rom_save_sfname
 
-        if selectedcore:
-            download_success, new_rom_fname, new_rom_sfname = download_rom_only(rom_fname,rom_sfname, rom_save_fname, rom_save_sfname, rom_dl_path, rom_postdlaction)
-            current_path = getTempDir()
-            current_save_fname = current_path+'/'+rom_save_fname
-            current_save_sfname = current_path+'/'+rom_save_sfname
+        if new_rom_fname is not None: #The file was unzipped, change from zip to the correct rom extension
+            current_save_fname = new_rom_fname
 
-            if new_rom_fname is not None: #The file was unzipped, change from zip to the correct rom extension
-                current_save_fname = new_rom_fname
+        if new_rom_sfname is not None: #The file was unzipped, change from zip to the correct rom extension
+            current_save_sfname = new_rom_sfname
 
-            if new_rom_sfname is not None: #The file was unzipped, change from zip to the correct rom extension
-                current_save_sfname = new_rom_sfname
-            
-            launch_game_listitem = xbmcgui.ListItem(current_save_fname, "0", "", "")
-            parameters = { "Addon.ID": selectedcore }
-            print selectedcore
-            launch_game_listitem.setInfo( type="game", infoLabels=parameters)
+        launch_game_listitem = xbmcgui.ListItem(current_save_fname, "0", "", "")
+        parameters = { }
+        launch_game_listitem.setInfo( type="game", infoLabels=parameters)
 
-            if xbmc.Player().isPlaying():
-                    xbmc.Player().stop()
-                    xbmc.sleep(100)
+        if xbmc.Player().isPlaying():
+                xbmc.Player().stop()
+                xbmc.sleep(100)
 
-            romwindow.closeDialog() #Need to close the dialog window for the game window to be in the front
-            xbmc.sleep(500) #This pause seems to help... I'm not really sure why
-            xbmc.Player().play(current_save_fname,launch_game_listitem)
+        romwindow.closeDialog() #Need to close the dialog window for the game window to be in the front
+        xbmc.sleep(500) #This pause seems to help... I'm not really sure why
+        xbmc.Player().play(current_save_fname,launch_game_listitem)
 
 class ROMWindow(xbmcgui.WindowXMLDialog):
     def __init__(self,strXMLname, strFallbackPath, strDefaultName, forceFallback, *args, **kwargs):

--- a/resources/lib/util.py
+++ b/resources/lib/util.py
@@ -725,57 +725,6 @@ def dlfile(url,dest):
     return result
 
 
-def selectlibretrocore():
-		
-	selectedCore = ''
-	addons = ['None']
-	
-	# success, installedAddons = readLibretroCores("all", True, platform)
-	success, installedAddons = readLibretroCores("all")
-	if(not success):
-		return False, ""
-	addons.extend(installedAddons)
-	
-	# success, uninstalledAddons = readLibretroCores("uninstalled", False, platform)
-	success, uninstalledAddons = readLibretroCores("uninstalled")
-	if(not success):
-		return False, ""
-	addons.extend(uninstalledAddons)
-	
-	dialog = xbmcgui.Dialog()
-	index = dialog.select('Select libretro core', addons)
-	print "index = " +str(index)
-	if(index == -1):
-		return False, ""
-	elif(index == 0):
-		print "return success"
-		return True, ""
-	else:
-		selectedCore = addons[index]
-		return True, selectedCore
-
-def readLibretroCores(enabledParam):
-	
-	addons = []
-	addonsJson = xbmc.executeJSONRPC('{ "jsonrpc": "2.0", "id": 1, "method": "Addons.GetAddons", "params": { "type": "kodi.gameclient", "enabled": "%s" } }' %enabledParam)
-	jsonResult = json.loads(addonsJson)	
-			
-	try:
-		for addonObj in jsonResult[u'result'][u'addons']:
-			id = addonObj[u'addonid']
-			# addon = xbmcaddon.Addon(id, installed=installedParam)
-			# # extensions and platforms are "|" separated, extensions may or may not have a leading "."
-			# addonPlatformStr = addon.getAddonInfo('platforms')
-			# addonPlatforms = addonPlatformStr.split("|")
-			# # for addonPlatform in addonPlatforms:
-			# # 	if(addonPlatform == platform):
-			addons.append(id)
-	except KeyError:
-		#no addons installed or found
-		return True, addons
-	# Logutil.log("addons: %s" %str(addons), util.LOG_LEVEL_INFO)
-	return True, addons
-
 def update_xml_header(current_path,current_filename,reg_exp,new_value):
 	full_reg_exp = '</'+reg_exp+'>' #Look for this
 	fout = open(current_path+'temp.xml', 'w') # out file


### PR DESCRIPTION
I'd like to consolidate logic for choosing libretro cores to avoid duplicating it across all plugins. Currently I'm implementing this selection in core, but the complexity is growing so I'm not sure where it'll end up.

The idea is that the add-on plays (via `xbmc.Player().play()`) a file or directory, and RetroPlayer figures out what file to run and what core to run it with, while taking the necessary steps to make this happen (like installing emulators). The current behavior is kind of complex (see my partial description [here](http://forum.kodi.tv/showthread.php?tid=173361&pid=2088270#pid2088270)) but should be pretty robust for playing files within zip archives.
